### PR TITLE
WIP: Add the abillity to disable the setting of securityContext for a deve…

### DIFF
--- a/pkg/k8s/deployments/translate_test.go
+++ b/pkg/k8s/deployments/translate_test.go
@@ -622,6 +622,177 @@ persistentVolume:
 	}
 }
 
+func Test_translateWithoutSecurityContext(t *testing.T) {
+	manifest := []byte(`name: web
+namespace: n
+image: web:latest
+sync:
+  - .:/app
+securityContext:
+  enabled: false`)
+	dev, err := model.Read(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dev.Username = "cindy"
+	dev.RegistryURL = "registry.okteto.dev"
+	d := dev.GevSandbox()
+	rule := dev.ToTranslationRule(dev, false)
+	tr := &model.Translation{
+		Interactive: true,
+		Name:        dev.Name,
+		Version:     model.TranslationVersion,
+		Deployment:  d,
+		Rules:       []*model.TranslationRule{rule},
+	}
+	err = translate(tr, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dOK := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					TerminationGracePeriodSeconds: &devTerminationGracePeriodSeconds,
+					SecurityContext:               &apiv1.PodSecurityContext{},
+					Volumes: []apiv1.Volume{
+						{
+							Name: oktetoSyncSecretVolume,
+							VolumeSource: apiv1.VolumeSource{
+								Secret: &apiv1.SecretVolumeSource{
+									SecretName: "okteto-web",
+									Items: []apiv1.KeyToPath{
+										{
+											Key:  "config.xml",
+											Path: "config.xml",
+											Mode: &mode444,
+										},
+										{
+											Key:  "cert.pem",
+											Path: "cert.pem",
+											Mode: &mode444,
+										},
+										{
+											Key:  "key.pem",
+											Path: "key.pem",
+											Mode: &mode444,
+										},
+									},
+								},
+							},
+						},
+						{
+							Name: dev.GetVolumeName(),
+							VolumeSource: apiv1.VolumeSource{
+								PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
+									ClaimName: dev.GetVolumeName(),
+									ReadOnly:  false,
+								},
+							},
+						},
+						{
+							Name: OktetoBinName,
+							VolumeSource: apiv1.VolumeSource{
+								EmptyDir: &apiv1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+					InitContainers: []apiv1.Container{
+						{
+							Name:            OktetoBinName,
+							Image:           model.OktetoBinImageTag,
+							ImagePullPolicy: apiv1.PullIfNotPresent,
+							Command:         []string{"sh", "-c", "cp /usr/local/bin/* /okteto/bin"},
+							VolumeMounts: []apiv1.VolumeMount{
+								{
+									Name:      OktetoBinName,
+									MountPath: "/okteto/bin",
+								},
+							},
+						},
+						{
+							Name:            OktetoInitVolumeContainerName,
+							Image:           "web:latest",
+							ImagePullPolicy: apiv1.PullIfNotPresent,
+							Command:         []string{"sh", "-cx", "echo initializing && ( [ \"$(ls -A /init-volume/1)\" ] || cp -R /app/. /init-volume/1 || true)"},
+							SecurityContext: &apiv1.SecurityContext{},
+							VolumeMounts: []apiv1.VolumeMount{
+								{
+									Name:      dev.GetVolumeName(),
+									ReadOnly:  false,
+									MountPath: "/init-volume/1",
+									SubPath:   model.SourceCodeSubPath,
+								},
+							},
+						},
+					},
+					Containers: []apiv1.Container{
+						{
+							Name:            "dev",
+							Image:           "web:latest",
+							ImagePullPolicy: apiv1.PullAlways,
+							Command:         []string{"/var/okteto/bin/start.sh"},
+							Args:            []string{"-r", "-v"},
+							Env: []apiv1.EnvVar{
+								{
+									Name:  "OKTETO_NAMESPACE",
+									Value: "n",
+								},
+								{
+									Name:  "OKTETO_NAME",
+									Value: "web",
+								},
+								{
+									Name:  "OKTETO_USERNAME",
+									Value: "cindy",
+								},
+							},
+							SecurityContext: &apiv1.SecurityContext{},
+							VolumeMounts: []apiv1.VolumeMount{
+								{
+									Name:      dev.GetVolumeName(),
+									ReadOnly:  false,
+									MountPath: "/var/syncthing",
+									SubPath:   model.SyncthingSubPath,
+								},
+								{
+									Name:      dev.GetVolumeName(),
+									ReadOnly:  false,
+									MountPath: model.RemoteMountPath,
+									SubPath:   model.RemoteSubPath,
+								},
+								{
+									Name:      dev.GetVolumeName(),
+									ReadOnly:  false,
+									MountPath: "/app",
+									SubPath:   model.SourceCodeSubPath,
+								},
+								{
+									Name:      oktetoSyncSecretVolume,
+									ReadOnly:  false,
+									MountPath: "/var/syncthing/secret/",
+								},
+								{
+									Name:      OktetoBinName,
+									ReadOnly:  false,
+									MountPath: "/var/okteto/bin",
+								},
+							},
+							LivenessProbe:  nil,
+							ReadinessProbe: nil,
+						},
+					},
+				},
+			},
+		},
+	}
+	marshalled, _ := yaml.Marshal(d.Spec.Template.Spec)
+	marshalledOK, _ := yaml.Marshal(dOK.Spec.Template.Spec)
+	if string(marshalled) != string(marshalledOK) {
+		t.Fatalf("Wrong d generation.\nActual %+v, \nExpected %+v", string(marshalled), string(marshalledOK))
+	}
+}
+
 func Test_translateWithDocker(t *testing.T) {
 	manifest := []byte(`name: web
 namespace: n

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -189,6 +189,7 @@ type SecurityContext struct {
 	RunAsGroup   *int64        `json:"runAsGroup,omitempty" yaml:"runAsGroup,omitempty"`
 	FSGroup      *int64        `json:"fsGroup,omitempty" yaml:"fsGroup,omitempty"`
 	Capabilities *Capabilities `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
+	Enabled      *bool         `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 }
 
 // Capabilities sets the linux capabilities of a container
@@ -566,8 +567,21 @@ func setBuildDefaults(build *BuildInfo) {
 	}
 }
 
+func (dev *Dev) SecurityContextEnabled() bool {
+	if dev.SecurityContext == nil {
+		return true
+	}
+	if dev.SecurityContext.Enabled == nil {
+		return true
+	}
+	return *dev.SecurityContext.Enabled
+}
+
 func (dev *Dev) setRunAsUserDefaults(main *Dev) {
 	if !main.PersistentVolumeEnabled() {
+		return
+	}
+	if !main.SecurityContextEnabled() {
 		return
 	}
 	if dev.SecurityContext == nil {

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -971,6 +971,56 @@ func TestPersistentVolumeEnabled(t *testing.T) {
 	}
 }
 
+func TestSecurityContextEnabled(t *testing.T) {
+	var tests = []struct {
+		name     string
+		manifest []byte
+		expected bool
+	}{
+		{
+			name: "default",
+			manifest: []byte(`
+      name: deployment
+      container: core
+      image: code/core:0.1.8`),
+			expected: true,
+		},
+		{
+			name: "set",
+			manifest: []byte(`
+      name: deployment
+      container: core
+      image: code/core:0.1.8
+      securityContext:
+        enabled: true`),
+			expected: true,
+		},
+		{
+			name: "disabled",
+			manifest: []byte(`
+      name: deployment
+      container: core
+      image: code/core:0.1.8
+      securityContext:
+        enabled: false`),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dev, err := Read(tt.manifest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if dev.SecurityContextEnabled() != tt.expected {
+				t.Errorf("Expecting %t but got %t", tt.expected, dev.SecurityContextEnabled())
+			}
+		})
+	}
+}
+
 func Test_ExpandEnv(t *testing.T) {
 	os.Setenv("BAR", "bar")
 	tests := []struct {


### PR DESCRIPTION
This adds an `enabled` flag to the securityContext schema of the Okteto manifest.

This will effectively disable setting of the securityContext of the development container which will allow Okteto to work with non-root containers in Openshift without explicitly defining `runAsUser`.

See https://github.com/okteto/okteto/issues/1658

